### PR TITLE
Make all reference lookups use borrow result instead of just reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+## 2019-11-24: 0.1.2
+### Added
+- Now items in queue can be looked up borrow using result, e.g. if `String` struct used as key, `&str` can be passed as lookup key.
+
+## 2019-10-27: 0.1.1
+### Added
+- Now `KeyedPriorityQueue` implements `Default` trait
+
+### Changed
+- Some clippy fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyed_priority_queue"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["AngelicosPhosphoros <xuzin.timur@gmail.com>"]
 edition = "2018"
 description = "Priority queue that support changing priority or early remove by key"


### PR DESCRIPTION
It allow use &str if keys are String.