### PR TITLE
Release 0.3.0: More lazy Entry API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,12 @@ jobs:
       script:
         - cd keyed_priority_queue
         - cargo test --verbose
+    # Minimal supported rustc
+    - rust: 1.46.0
+      script:
+        - cargo test --verbose
     # Unsafe soundness prove
-    - rust: nightly-2020-10-01
+    - rust: nightly-2020-10-05
       script:
         - rustup component add miri
         - cargo miri test -j16 --verbose --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ jobs:
       script:
         - cd keyed_priority_queue
         - cargo test --verbose
+    # Unsafe soundness prove
+    - rust: nightly-2020-10-01
+      script:
+        - rustup component add miri
+        - cargo miri test -j16 --verbose --all-features
     # Validate readyness to publish
     - rust: stable
       script: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 2020-10-11: 0.3.0
+- Stopped to modify internal map in Entry API until user request it. However, this requires using of `unsafe` code. More details [here](https://github.com/AngelicosPhosphoros/keyed_priority_queue/commit/145e9ceb2d6a31617b5bf4bf282f0f4e66ec7a00)
+- Added [Miri](https://github.com/rust-lang/miri) tests to CI
+- Added minimal rustc supported version: `1.46.0`
+- Removed some unneeded code and fixed some docs
+- Refactored internal code to validate it correctness by type system.
+
+
 ## 2020-03-25: 0.2.1
 Fixed typo in Readme.md
 

--- a/Readme.md
+++ b/Readme.md
@@ -10,12 +10,14 @@
 A Rust library with priority queue that supports changing of priority item in queue or early removal.
 To change priority you need to use some key.
 
+Minimal supported Rust version: `1.46.0`.
+
 ## Usage
 
 Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
-keyed_priority_queue = "0.2"
+keyed_priority_queue = "0.3"
 ```
 
 The example of code:

--- a/keyed_priority_queue/Cargo.toml
+++ b/keyed_priority_queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyed_priority_queue"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["AngelicosPhosphoros <xuzin.timur@gmail.com>"]
 edition = "2018"
 description = "Priority queue that support changing priority or early remove by key"

--- a/keyed_priority_queue/src/editable_binary_heap.rs
+++ b/keyed_priority_queue/src/editable_binary_heap.rs
@@ -10,6 +10,7 @@ use crate::mediator::MediatorIndex;
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub(crate) struct HeapIndex(usize);
 
+#[derive(Copy, Clone)]
 struct HeapEntry<TPriority> {
     outer_pos: MediatorIndex,
     priority: TPriority,
@@ -34,6 +35,7 @@ impl<TPriority> HeapEntry<TPriority> {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct BinaryHeap<TPriority>
 where
     TPriority: Ord,
@@ -166,6 +168,7 @@ impl<TPriority: Ord> BinaryHeap<TPriority> {
         self.data.clear()
     }
 
+    #[inline]
     pub(crate) fn iter(&self) -> BinaryHeapIterator<TPriority> {
         BinaryHeapIterator {
             inner: self.data.iter(),
@@ -306,17 +309,6 @@ impl<'a, TPriority> Iterator for BinaryHeapIterator<'a, TPriority> {
 
 // Default implementations
 
-impl<TPriority: Clone> Clone for HeapEntry<TPriority> {
-    fn clone(&self) -> Self {
-        Self {
-            outer_pos: self.outer_pos,
-            priority: self.priority.clone(),
-        }
-    }
-}
-
-impl<TPriority: Copy> Copy for HeapEntry<TPriority> {}
-
 impl<TPriority: Debug> Debug for HeapEntry<TPriority> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
@@ -327,15 +319,8 @@ impl<TPriority: Debug> Debug for HeapEntry<TPriority> {
     }
 }
 
-impl<TPriority: Clone + Ord> Clone for BinaryHeap<TPriority> {
-    fn clone(&self) -> Self {
-        Self {
-            data: self.data.clone(),
-        }
-    }
-}
-
 impl<TPriority: Debug + Ord> Debug for BinaryHeap<TPriority> {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         self.data.fmt(f)
     }

--- a/keyed_priority_queue/src/editable_binary_heap.rs
+++ b/keyed_priority_queue/src/editable_binary_heap.rs
@@ -100,7 +100,7 @@ impl<TPriority: Ord> BinaryHeap<TPriority> {
             return None;
         }
         if position.plus1() == self.len() {
-            let result = self.data.pop().unwrap();
+            let result = self.data.pop().expect("At least 1 item");
             return Some(result.conv_pair());
         }
 

--- a/keyed_priority_queue/src/keyed_priority_queue.rs
+++ b/keyed_priority_queue/src/keyed_priority_queue.rs
@@ -525,7 +525,7 @@ impl<TKey: Hash + Eq, TPriority: Ord> KeyedPriorityQueue<TKey, TPriority> {
             .remove(heap_to_rem, |index, heap_idx| {
                 *key_to_pos.get_index_mut(index) = heap_idx
             })
-            .unwrap();
+            .expect("Checked by key_to_pos");
         debug_assert_eq!(position, removed_idx);
 
         let (removed_key, _) = key_to_pos.swap_remove_index(position);

--- a/keyed_priority_queue/src/lib.rs
+++ b/keyed_priority_queue/src/lib.rs
@@ -147,7 +147,7 @@
 //! ```
 //!
 
-#[forbid(unsafe_code)]
+//#[forbid(unsafe_code)]
 mod editable_binary_heap;
 mod keyed_priority_queue;
 mod mediator;

--- a/keyed_priority_queue/src/lib.rs
+++ b/keyed_priority_queue/src/lib.rs
@@ -3,7 +3,7 @@
 //! It uses HashMap and own implementation of binary heap to achieve this.
 //!
 //! Each entry has associated *key* and *priority*.
-//! Keys must be unique, clonable, and hashable; priorities must implement Ord trait.
+//! Keys must be unique, and hashable; priorities must implement Ord trait.
 //!
 //! Popping returns element with biggest priority.
 //! Pushing adds element to queue.
@@ -147,7 +147,6 @@
 //! ```
 //!
 
-//#[forbid(unsafe_code)]
 mod editable_binary_heap;
 mod keyed_priority_queue;
 mod mediator;

--- a/keyed_priority_queue/src/lib.rs
+++ b/keyed_priority_queue/src/lib.rs
@@ -150,6 +150,7 @@
 #[forbid(unsafe_code)]
 mod editable_binary_heap;
 mod keyed_priority_queue;
+mod mediator;
 
 pub use crate::keyed_priority_queue::{
     Entry, KeyedPriorityQueue, KeyedPriorityQueueBorrowIter, KeyedPriorityQueueIterator,

--- a/keyed_priority_queue/src/mediator.rs
+++ b/keyed_priority_queue/src/mediator.rs
@@ -1,0 +1,151 @@
+use crate::editable_binary_heap::HeapIndex;
+use indexmap::map::{IndexMap, OccupiedEntry as IMOccupiedEntry, VacantEntry as IMVacantEntry};
+use std::borrow::Borrow;
+use std::hash::Hash;
+
+/// Wrapper around possible outer vec index
+/// Used to avoid mux up with heap index
+/// And to make sure that `Mediator` indexed only with MediatorIndex
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+pub(crate) struct MediatorIndex(pub(crate) usize);
+
+/// This is wrapper over over indexmap that uses `MediatorIndex` as index.
+/// Also it centralized checking for panics
+#[derive(Clone, Debug)]
+pub(crate) struct Mediator<TKey: Hash + Eq> {
+    map: IndexMap<TKey, HeapIndex>,
+}
+
+#[inline(always)]
+fn with_copied_heap_index<'a, T>((k, &i): (&'a T, &HeapIndex)) -> (&'a T, HeapIndex) {
+    (k, i)
+}
+
+pub(crate) struct VacantEntry<'a, TKey: 'a + Hash + Eq>(IMVacantEntry<'a, TKey, HeapIndex>);
+pub(crate) struct OccupiedEntry<'a, TKey: 'a + Hash + Eq>(IMOccupiedEntry<'a, TKey, HeapIndex>);
+pub(crate) enum MediatorEntry<'a, TKey: 'a + Hash + Eq> {
+    Vacant(VacantEntry<'a, TKey>),
+    Occupied(OccupiedEntry<'a, TKey>),
+}
+
+impl<TKey> Mediator<TKey>
+where
+    TKey: Hash + Eq,
+{
+    #[inline(always)]
+    pub(crate) fn new() -> Self {
+        Self {
+            map: IndexMap::new(),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            map: IndexMap::with_capacity(capacity),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.map.reserve(additional)
+    }
+
+    #[inline(always)]
+    pub(crate) fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    #[inline(always)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    #[inline(always)]
+    pub(crate) fn clear(&mut self) {
+        self.map.clear()
+    }
+
+    #[inline(always)]
+    pub(crate) fn get_index(&self, MediatorIndex(position): MediatorIndex) -> (&TKey, HeapIndex) {
+        self.map
+            .get_index(position)
+            .map(with_copied_heap_index)
+            .expect("All mediator indexes must be valid")
+    }
+
+    #[inline(always)]
+    pub(crate) fn entry(&mut self, key: TKey) -> MediatorEntry<TKey> {
+        match self.map.entry(key) {
+            indexmap::map::Entry::Occupied(v) => MediatorEntry::Occupied(OccupiedEntry(v)),
+            indexmap::map::Entry::Vacant(v) => MediatorEntry::Vacant(VacantEntry(v)),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn get<Q>(&self, key: &Q) -> Option<HeapIndex>
+    where
+        TKey: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.map.get(key).map(|&x| x)
+    }
+
+    #[inline(always)]
+    pub(crate) fn get_full<'a, Q>(&'a self, key: &Q) -> Option<(MediatorIndex, &'a TKey, HeapIndex)>
+    where
+        TKey: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.map
+            .get_full(key)
+            .map(|(idx, key, &val)| (MediatorIndex(idx), key, val))
+    }
+
+    #[inline(always)]
+    pub(crate) fn swap_remove_index(
+        &mut self,
+        MediatorIndex(index): MediatorIndex,
+    ) -> (TKey, HeapIndex) {
+        self.map
+            .swap_remove_index(index)
+            .expect("All mediator indexes must be valid")
+    }
+
+    #[inline(always)]
+    pub(crate) fn get_index_mut(&mut self, MediatorIndex(index): MediatorIndex) -> &mut HeapIndex {
+        self.map
+            .get_index_mut(index)
+            .expect("All mediator indexes must be valid")
+            .1
+    }
+
+    #[cfg(test)]
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&TKey, HeapIndex)> {
+        self.map.iter().map(with_copied_heap_index)
+    }
+}
+
+impl<'a, TKey: 'a + Hash + Eq> VacantEntry<'a, TKey> {
+    #[inline(always)]
+    pub(crate) fn insert(self, value: HeapIndex) {
+        self.0.insert(value);
+    }
+
+    #[inline(always)]
+    pub(crate) fn index(&self) -> MediatorIndex {
+        MediatorIndex(self.0.index())
+    }
+}
+
+impl<'a, TKey: 'a + Hash + Eq> OccupiedEntry<'a, TKey> {
+    #[inline(always)]
+    pub(crate) fn index(&self) -> MediatorIndex {
+        MediatorIndex(self.0.index())
+    }
+
+    #[inline(always)]
+    pub(crate) fn get(&self) -> HeapIndex {
+        *self.0.get()
+    }
+}


### PR DESCRIPTION
- Stopped to modify internal map in Entry API until user request it. However, this requires using of `unsafe` code. More details [here](https://github.com/AngelicosPhosphoros/keyed_priority_queue/commit/145e9ceb2d6a31617b5bf4bf282f0f4e66ec7a00)
- Added [Miri](https://github.com/rust-lang/miri) tests to CI
- Added minimal rustc supported version: `1.46.0`
- Removed some unneeded code and fixed some docs
- Refactored internal code to validate it correctness by type system.