### PR TITLE
Fixed binary heap invalidation in removing by key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2021-02-21: 0.3.2
+- Fixed bug in priority queue implementation.
+
 ## 2020-12-21: 0.3.1
 - Added ability to use custom hasher
 

--- a/keyed_priority_queue/Cargo.toml
+++ b/keyed_priority_queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyed_priority_queue"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["AngelicosPhosphoros <xuzin.timur@gmail.com>"]
 edition = "2018"
 description = "Priority queue that support changing priority or early remove by key"

--- a/keyed_priority_queue/src/keyed_priority_queue.rs
+++ b/keyed_priority_queue/src/keyed_priority_queue.rs
@@ -1203,4 +1203,26 @@ mod tests {
         }
         assert_eq!(&res, &[(1, 10), (5, 5), (4, 4), (2, 2), (0, 0)]);
     }
+
+    #[test]
+    fn test_remove_change_tree() {
+        use std::cmp::Reverse;
+        let mut queue = KeyedPriorityQueue::new();
+
+        queue.push(0, Reverse(300));
+        queue.push(1, Reverse(500));
+        queue.push(2, Reverse(400));
+        queue.push(3, Reverse(400));
+        queue.push(4, Reverse(600));
+        queue.push(5, Reverse(100));
+        queue.push(6, Reverse(200));
+        queue.remove(&1);
+
+        let mut list = Vec::new();
+        while let Some((_, timestamp)) = queue.pop() {
+            list.push(timestamp.0);
+        }
+
+        assert_eq!(list, [100, 200, 300, 400, 400, 600])
+    }
 }


### PR DESCRIPTION
Error caused by moving one child of binary heap tree to another subtree and inproper rebalancing.
Fixes https://github.com/AngelicosPhosphoros/keyed_priority_queue/issues/12